### PR TITLE
删除 @ , 避免 yaml 扩展没有安装导致的无任何错误响应的问题

### DIFF
--- a/class/Gini/Config.php
+++ b/class/Gini/Config.php
@@ -110,7 +110,7 @@ class Config
                     $content = preg_replace_callback('/\$\{([A-Z0-9_]+?)\}/', function ($matches) {
                         return $_SERVER[$matches[1]] ?: $matches[0];
                     }, $content);
-                    $config = (array) @yaml_parse($content);
+                    $config = (array) yaml_parse($content);
                     $items[$category] = \Gini\Util::arrayMergeDeep($items[$category], $config);
                     break;
                 }


### PR DESCRIPTION
http://php.net/manual/zh/language.operators.errorcontrol.php :
> Warning
目前的“@”错误控制运算符前缀甚至使导致脚本终止的严重错误的错误报告也失效。这意味着如果在某个不存在或者敲错了字母的函数调用前用了“@”来抑制错误信息，那脚本会没有任何迹象显示原因而死在那里。