### PR TITLE
对those中where的强转

### DIFF
--- a/class/Gini/Those.php
+++ b/class/Gini/Those.php
@@ -222,7 +222,7 @@ namespace Gini {
                     $this->_join = array_merge($this->_join, $v->_join);
                 }
                 if ($v->_where) {
-                    $this->_where = array_merge($this->_where, $v->_where);
+                    $this->_where = array_merge((array)$this->_where, $v->_where);
                 }
             } else {
                 foreach ($values as $v) {
@@ -250,7 +250,7 @@ namespace Gini {
                     $this->_join = array_merge($this->_join, $v->_join);
                 }
                 if ($v->_where) {
-                    $this->_where = array_merge($this->_where, $v->_where);
+                    $this->_where = array_merge((array)$this->_where, $v->_where);
                     $this->_where[] = 'AND';
                 }
                 $this->_where[] = $field_name.' IS NOT NULL';


### PR DESCRIPTION
在使用
$users = those('users')->whose('father')->isIn(
        those('users')->whose('email')->contains('genee')
    );
的时候,因没有前置查询条件并且首个查询条件为isIn的关联查询
those对象的$_where会为空,但条件中的$_where不为空，会导致array_merge的时候报错