### PR TITLE
添加ORM支持的类型: longtext

### DIFF
--- a/class/Gini/ORM.php
+++ b/class/Gini/ORM.php
@@ -272,6 +272,8 @@ abstract class ORM
                 case 'string':
                     if ($pv == '*') {
                         $field['type'] = 'text';
+                    } elseif ($pv == 'long') {
+                        $field['type'] = 'longtext';
                     } else {
                         $field['type'] = 'varchar('.($pv ?: 255).')';
                     }


### PR DESCRIPTION
数据库text类型只能存储65535个字符。如果在数据库中存储大段文章，就需要用到longtext。