### PR TITLE
如果session没有变化，就不要讲session再写回去

### DIFF
--- a/class/Gini/Session.php
+++ b/class/Gini/Session.php
@@ -160,6 +160,8 @@ class Session
     {
         if (self::$_rawData!==session_encode()) {
             session_write_close();
+            return;
         }
+        session_abort();
     }
 }


### PR DESCRIPTION
1. 减少IO
2. 如果使用redis等存储session，解决没有文件锁导致的session不一致问题