### PR TITLE
去掉http_response_code的短路

### DIFF
--- a/class/Gini/CGI/Response/HTML.php
+++ b/class/Gini/CGI/Response/HTML.php
@@ -15,7 +15,7 @@ class HTML implements \Gini\CGI\Response
 
     public function output()
     {
-        $this->_code==200 or http_response_code($this->_code);
+        http_response_code($this->_code);
         header('Content-Type: text/html; charset:utf-8');
         file_put_contents('php://output', (string) $this->_content);
     }

--- a/class/Gini/CGI/Response/JSON.php
+++ b/class/Gini/CGI/Response/JSON.php
@@ -15,7 +15,7 @@ class JSON implements \Gini\CGI\Response
 
     public function output()
     {
-        $this->_code==200 or http_response_code($this->_code);
+        http_response_code($this->_code);
         header('Content-Type: application/json; charset=utf-8');
         if ($this->_content !== null) {
             file_put_contents(


### PR DESCRIPTION
在守护进程模式下 如果不重新设置http_response_code 下一个请求会复用前一个请求的http_response_code
建议重新设置