### PR TITLE
增加对抽象类实例化的容错

### DIFF
--- a/class/Gini/API.php
+++ b/class/Gini/API.php
@@ -49,7 +49,7 @@ class API
                     $class = '\Gini\Controller\API';
                 }
 
-                $reflection = new ReflectionClass($class);
+                $reflection = new \ReflectionClass($class);
                 if (class_exists($class) && $method[0] != '_' && !$reflection->isAbstract()) {
                     $method = 'action'.$method;
                     $o = \Gini\IoC::construct($class);

--- a/class/Gini/API.php
+++ b/class/Gini/API.php
@@ -18,7 +18,7 @@ namespace Gini;
 
 class API
 {
-    public static function dispatch(array $data, $env = null)
+    public static function dispatch(array $data, $env = [])
     {
         try {
             $id = $data['id'] ?: null;

--- a/class/Gini/API.php
+++ b/class/Gini/API.php
@@ -18,10 +18,11 @@ namespace Gini;
 
 class API
 {
-    public static function dispatch(array $data, $env)
+    public static function dispatch(array $data, $env = null)
     {
         try {
             $id = $data['id'] ?: null;
+            $env = $env ?: \Gini\CGI::defaultEnv();
 
             if (!isset($data['method'])
                 || !isset($data['params']) || !isset($data['jsonrpc'])

--- a/class/Gini/API.php
+++ b/class/Gini/API.php
@@ -18,7 +18,7 @@ namespace Gini;
 
 class API
 {
-    public static function dispatch(array $data)
+    public static function dispatch(array $data, $env)
     {
         try {
             $id = $data['id'] ?: null;
@@ -40,20 +40,21 @@ class API
                 // might not be necessary, since __invoke is the magic method since PHP 5.3
                 $o = \Gini\IoC::construct($class);
                 $o->app = \Gini\Core::app();
+                $o->env = $env;
                 $callback = [$o, '__invoke'];
             } else {
                 $method = array_pop($path_arr);
                 if (count($path_arr) > 0) {
                     $class = '\Gini\Controller\API\\'.implode('\\', $path_arr);
                 } else {
-                    $class = '\Gini\Controller\API';
+                    $class = '\Gini\Controller\API\Index';
                 }
 
-                $reflection = new \ReflectionClass($class);
-                if (class_exists($class) && $method[0] != '_' && !$reflection->isAbstract()) {
+                if (class_exists($class) && $method[0] != '_') {
                     $method = 'action'.$method;
                     $o = \Gini\IoC::construct($class);
                     $o->app = \Gini\Core::app();
+                    $o->env = $env;
                     if (method_exists($o, $method)) {
                         $callback = [$o, $method];
                     } elseif (function_exists($class.'\\'.$method)) {

--- a/class/Gini/API.php
+++ b/class/Gini/API.php
@@ -49,7 +49,8 @@ class API
                     $class = '\Gini\Controller\API';
                 }
 
-                if (class_exists($class) && $method[0] != '_') {
+                $reflection = new ReflectionClass($class);
+                if (class_exists($class) && $method[0] != '_' && !$reflection->isAbstract()) {
                     $method = 'action'.$method;
                     $o = \Gini\IoC::construct($class);
                     $o->app = \Gini\Core::app();

--- a/class/Gini/Controller/API/Index.php
+++ b/class/Gini/Controller/API/Index.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Gini\Controller\API;
+
+class Index extends \Gini\Controller\API
+{
+    
+}

--- a/class/Gini/Controller/CGI/API.php
+++ b/class/Gini/Controller/CGI/API.php
@@ -26,7 +26,7 @@ final class API extends \Gini\Controller\CGI
                 'id' => $id,
             ];
         } else {
-            $response = \Gini\API::dispatch((array)$post);
+            $response = \Gini\API::dispatch((array)$post, $this->env);
         }
 
         return \Gini\IoC::construct('\Gini\CGI\Response\JSON', $response);


### PR DESCRIPTION
测试时候发现 如果进入 `else`:

```
if (count($path_arr) > 0) {
    $class = '\Gini\Controller\API\\'.implode('\\', $path_arr);
} else {
    $class = '\Gini\Controller\API';
}
```

实际上 `\Gini\Controller\API` 是抽象类 会抛出异常