### PR TITLE
增加可以取消配置项的标识符

### DIFF
--- a/class/Gini/Config.php
+++ b/class/Gini/Config.php
@@ -109,7 +109,9 @@ class Config
                     $content = file_get_contents($file);
                     $replaceCallback = function ($matches) {
                         $defaultValue = $matches[2] ? trim($matches[2], '"\'') : $matches[0];
-                        return getenv($matches[1]) ?: $defaultValue;
+                        $envValue = getenv($matches[1]);
+                        if ($envValue == '@DISABLE') return '';
+                        return getenv($envValue) ?: $defaultValue;
                     };
                     $content = preg_replace_callback('/\{\{([A-Z0-9_]+?)\s*(?:\:\=\s*(.+?))?\s*\}\}/', $replaceCallback, $content);
                     $content = preg_replace_callback('/\$\{([A-Z0-9_]+?)\s*(?:\:\=\s*(.+?))?\s*\}/', $replaceCallback, $content);


### PR DESCRIPTION
由于配置文件采用类似继承方式
env中需要增加一个标志`@DISABLE`方便取消引用模块的配置项