### PR TITLE
修正一个关联表表名异常的bug

### DIFF
--- a/ci/test/ORM/Those.php
+++ b/ci/test/ORM/Those.php
@@ -222,7 +222,7 @@ class Those extends \Gini\PHPUnit\TestCase\CLI
         $this->assertAttributeEquals('SELECT DISTINCT "t0"."id","t0"."_extra","t0"."name","t0"."money","t0"."father_id","t0"."description" FROM "user" AS "t0" INNER JOIN "_user_friend" AS "t1" ON "t1"."user_id"="t0"."id" INNER JOIN "user" AS "t2" ON "t1"."friend_id"="t2"."id" INNER JOIN "_user_friend" AS "t3" ON "t3"."user_id"="t2"."id" WHERE "t0"."gender"=1 AND "t3"."friend_id"=0', 'SQL', $those);
     }
 
-    public function testLeftJoin(){
+    public function testFieldOfField(){
 
         $db = self::getMockBuilder('\Gini\Database')
             ->setMockClassName('MOBJ_'.uniqid())

--- a/class/Gini/Those.php
+++ b/class/Gini/Those.php
@@ -372,7 +372,7 @@ namespace Gini {
                 } else {
                     if ($pivotName) {
                         $fieldName = $manyStructure[$field]['object'];
-                        $tableName = $o->tableName();
+                        $tableName = a($fieldName)->tableName();
                         if (!isset($this->_join[$fieldKey])) {
                             $this->_joinedTables[$fieldKey] = $fieldTable = 't'.$this->uniqid();
                             $pivotKey = "$fieldKey@pivot";
@@ -383,7 +383,7 @@ namespace Gini {
                         }
                     } else {
                         $fieldName = $structure[$field]['object'];
-                        $tableName = $o->tableName();
+                        $tableName = a($fieldName)->tableName();
                         if (!isset($this->_join[$fieldKey])) {
                             $this->_joinedTables[$fieldKey] = $fieldTable = 't'.$this->uniqid();
                             $this->_join[$fieldKey] = 'INNER JOIN '.$db->ident($tableName)

--- a/class/Gini/Those.php
+++ b/class/Gini/Those.php
@@ -372,19 +372,21 @@ namespace Gini {
                 } else {
                     if ($pivotName) {
                         $fieldName = $manyStructure[$field]['object'];
+                        $tableName = $o->tableName();
                         if (!isset($this->_join[$fieldKey])) {
                             $this->_joinedTables[$fieldKey] = $fieldTable = 't'.$this->uniqid();
                             $pivotKey = "$fieldKey@pivot";
                             $pivotTable = $this->_joinedTables[$pivotKey];
-                            $this->_join[$fieldKey] = 'INNER JOIN '.$db->ident($fieldName)
+                            $this->_join[$fieldKey] = 'INNER JOIN '.$db->ident($tableName)
                                 .' AS '.$db->quoteIdent($fieldTable)
                                 .' ON '.$db->ident($pivotTable, $field.'_id').'='.$db->ident($fieldTable, 'id');
                         }
                     } else {
                         $fieldName = $structure[$field]['object'];
+                        $tableName = $o->tableName();
                         if (!isset($this->_join[$fieldKey])) {
                             $this->_joinedTables[$fieldKey] = $fieldTable = 't'.$this->uniqid();
-                            $this->_join[$fieldKey] = 'INNER JOIN '.$db->ident($fieldName)
+                            $this->_join[$fieldKey] = 'INNER JOIN '.$db->ident($tableName)
                                 .' AS '.$db->quoteIdent($fieldTable)
                                 .' ON '.$db->ident($table, $field.'_id').'='.$db->ident($fieldTable, 'id');
                         }


### PR DESCRIPTION
当形如a.b_c.d的关联表搜索时会解析为 left join b/c as t3 ....