### PR TITLE
增加 rpc CURLOPT_SSL_VERIFYHOST 参数

### DIFF
--- a/class/Gini/RPC.php
+++ b/class/Gini/RPC.php
@@ -136,6 +136,7 @@ class RPC
             CURLOPT_COOKIEJAR => $cookie_file,
             CURLOPT_COOKIEFILE => $cookie_file,
             CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => false,
             CURLOPT_URL => $this->_url,
             CURLOPT_AUTOREFERER => false,
             CURLOPT_FOLLOWLOCATION => false,


### PR DESCRIPTION
防止服务器间通信无法通过